### PR TITLE
README: add MacPorts install info

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ There are multiple options for installing WebSocat. From easy to hard:
 * If you're on Linux Debian or Ubuntu (or other dpkg-based), try downloading a pre-build deb package from [GitHub releases][releases] and install from GUI or with command like `gdebi websocat_..._.deb`
 * If you're on Fedora, you can install WebSocat from [Copr](https://copr.fedorainfracloud.org/coprs/atim/websocat/): `sudo dnf copr enable atim/websocat -y && sudo dnf install websocat`
 * If you're on FreeBSD, you may install WebSocat with the following command: `pkg install websocat`.
-* If you're on Mac, you can do `brew install websocat`.
+* If you're on macOS, you can do:
+  * `brew install websocat` using [Homebrew](https://brew.sh)
+  * `sudo port install websocat` using [MacPorts](https://www.macports.org)
 * Download a pre-build executable and install it to PATH.
 * Install the [Rust toolchain](https://rustup.rs/) and do `cargo install --features=ssl websocat`. If something fails with a `-sys` crate, try without `--features=ssl`;
 * Build Websocat from source code (see below), then move `target/release/websocat` somewhere to the PATH.


### PR DESCRIPTION
Update macOS installation instructions to also include how to install using [MacPorts](https://www.macports.org)