### PR TITLE
Add options to close connection with a status code and message

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,10 @@ OPTIONS:
             [A] Number of pending queued messages for broadcast reuser [default: 16]
 
     -B, --buffer-size <buffer_size>                                  Maximum message size, in bytes [default: 65536]
+        --close-reason <close_reason>
+            Close connection with a reason message. This option only takes effect if --close-status-code option is
+            provided as well.
+        --close-status-code <close_status_code>                      Close connection with a status code.
     -H, --header <custom_headers>...
             Add custom HTTP header to websocket client request. Separate header name and value with a colon and
             optionally a single space. Can be used multiple times. Note that single -H may eat multiple further

--- a/doc.md
+++ b/doc.md
@@ -123,6 +123,10 @@ OPTIONS:
             [A] Number of pending queued messages for broadcast reuser [default: 16]
 
     -B, --buffer-size <buffer_size>                                  Maximum message size, in bytes [default: 65536]
+        --close-reason <close_reason>
+            Close connection with a reason message. This option only takes effect if --close-status-code option is
+            provided as well.
+        --close-status-code <close_status_code>                      Close connection with a status code.
     -H, --header <custom_headers>...
             Add custom HTTP header to websocket client request. Separate header name and value with a colon and
             optionally a single space. Can be used multiple times. Note that single -H may eat multiple further

--- a/src/main.rs
+++ b/src/main.rs
@@ -483,6 +483,15 @@ struct Opt {
     #[structopt(long = "--base64-text")]
     pub ws_text_base64: bool,
 
+    /// Close connection with a status code.
+    #[structopt(long = "--close-status-code")]
+    pub close_status_code: Option<u16>,
+
+    /// Close connection with a reason message. This option only takes effect if
+    /// --close-status-code option is provided as well.
+    #[structopt(long = "--close-reason")]
+    pub close_reason: Option<String>,
+
     /// [A] On UNIX, set stdin and stdout to nonblocking mode instead of spawning a thread.
     /// This should improve performance, but may break other programs running on the same console.
     #[structopt(long = "--async-stdio")]
@@ -768,6 +777,8 @@ fn run() -> Result<()> {
             ws_binary_prefix
             ws_binary_base64
             ws_text_base64
+            close_status_code
+            close_reason
             asyncstdio
             foreachmsg_wait_reads
             announce_listens

--- a/src/options.rs
+++ b/src/options.rs
@@ -89,6 +89,8 @@ pub struct Options {
     pub ws_binary_prefix: Option<String>,
     pub ws_binary_base64: bool,
     pub ws_text_base64: bool,
+    pub close_status_code: Option<u16>,
+    pub close_reason: Option<String>,
 
     /// Only affects linter
     pub asyncstdio: bool,


### PR DESCRIPTION
Add these two options:

```
        --close-reason <close_reason>
            Close connection with a reason message. This option only takes effect if --close-status-code option is
            provided as well.
        --close-status-code <close_status_code>                      Close connection with a status code.
```