### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ There are multiple options for installing WebSocat. From easy to hard:
 
 * If you're on Fedora, you can install WebSocat from [Copr](https://copr.fedorainfracloud.org/coprs/atim/websocat/): `sudo dnf copr enable atim/websocat -y && sudo dnf install websocat`
 * If you're on FreeBSD, you may install WebSocat with the following command: `pkg install websocat`.
-* If you're on Linux Debian or Ubuntu (or other dpkg-based), try downloading a pre-build executable from [GitHub releases][releases]. Websocat is not yet officially packaged for Debian. Some older versions of Websocat may also have Debian package files avaialble on Github releases.
+* If you're on Linux Debian or Ubuntu (or other dpkg-based), try downloading a pre-build executable from [GitHub releases][releases]. Websocat is not yet officially packaged for Debian. Some older versions of Websocat may also have Debian package files available on Github releases.
 * If you're on macOS, you can do:
   * `brew install websocat` using [Homebrew](https://brew.sh)
   * `sudo port install websocat` using [MacPorts](https://www.macports.org)
@@ -370,7 +370,7 @@ Full list of address types:
 	wss-listen:     	Listen for secure WebSocket connections on a TCP port
 	http:           	[A] Issue HTTP request, receive a 1xx or 2xx reply, then pass
 	asyncstdio:     	[A] Set stdin and stdout to nonblocking mode, then use it as a communication counterpart. UNIX-only.
-	inetd:          	Like `asyncstdio:`, but intented for inetd(8) usage. [A]
+	inetd:          	Like `asyncstdio:`, but intended for inetd(8) usage. [A]
 	tcp:            	Connect to specified TCP host and port. Argument is a socket address.
 	tcp-listen:     	Listen TCP port on specified address.
 	ssl-listen:     	Listen for SSL connections on a TCP port

--- a/doc.md
+++ b/doc.md
@@ -405,7 +405,7 @@ Example: SSH transport
 Internal name for --dump-spec: Inetd
 
 
-Like `asyncstdio:`, but intented for inetd(8) usage. [A]
+Like `asyncstdio:`, but intended for inetd(8) usage. [A]
 
 Automatically enables `-q` (`--quiet`) mode.
 
@@ -1168,7 +1168,7 @@ Note that attacker may duplicate, drop or reorder messages, including between di
 
 Each encrypted message is 12 bytes bigger than original message.
 
-Assocated --crypto-key option accepts the following prefixes:
+Associated --crypto-key option accepts the following prefixes:
 
 - `file:` prefix means that Websocat should read 32-byte file and use it as a key.
 - `base64:` prefix means the rest of the value is base64-encoded 32-byte buffer
@@ -1207,7 +1207,7 @@ Example: `(stty raw -echo; websocat -b exit_on_specific_byte:stdio: tcp:127.0.0.
 
 
   
-### Address types or specifiers to be implemeted later:
+### Address types or specifiers to be implemented later:
 
 `sctp:`, `speedlimit:`, `quic:`
 
@@ -1222,7 +1222,7 @@ then accept a websocket connection over the previous websocket used as a transpo
 then connect to a websocket using previous step as a transport,
 then forward resulting connection to the TCP port.
 
-(Excercise to the reader: manage to make it actually connect to 5678).
+(Exercise to the reader: manage to make it actually connect to 5678).
 
 
 

--- a/moreexamples.md
+++ b/moreexamples.md
@@ -318,7 +318,7 @@ WantedBy=sockets.target
 ```
 
 
-`/etc/systemd/system/qqq.service` (note the absense of  `@`).
+`/etc/systemd/system/qqq.service` (note the absence of  `@`).
 
 ```
 [Unit]

--- a/src/crypto_peer.rs
+++ b/src/crypto_peer.rs
@@ -51,7 +51,7 @@ Note that attacker may duplicate, drop or reorder messages, including between di
 
 Each encrypted message is 12 bytes bigger than original message.
 
-Assocated --crypto-key option accepts the following prefixes:
+Associated --crypto-key option accepts the following prefixes:
 
 - `file:` prefix means that Websocat should read 32-byte file and use it as a key.
 - `base64:` prefix means the rest of the value is base64-encoded 32-byte buffer

--- a/src/help.rs
+++ b/src/help.rs
@@ -231,7 +231,7 @@ Some address types may be "aliases" to other address types or combinations of ov
     println!(
         r#"
   
-### Address types or specifiers to be implemeted later:
+### Address types or specifiers to be implemented later:
 
 `sctp:`, `speedlimit:`, `quic:`
 
@@ -246,7 +246,7 @@ then accept a websocket connection over the previous websocket used as a transpo
 then connect to a websocket using previous step as a transport,
 then forward resulting connection to the TCP port.
 
-(Excercise to the reader: manage to make it actually connect to 5678).
+(Exercise to the reader: manage to make it actually connect to 5678).
 "#
     );
 }

--- a/src/http_peer.rs
+++ b/src/http_peer.rs
@@ -334,7 +334,7 @@ pub fn http_response_post_sse_peer(
 ) -> BoxedNewPeerFuture {
     let (r, w, hup) = (inner_peer.0, inner_peer.1, inner_peer.2);
 
-    warn!("Note: http-post-see mode is not tested and may intergrate poorly into current Websocat architecuture. Expect it to be of lower quality than other Websocat modes.");
+    warn!("Note: http-post-see mode is not tested and may integrate poorly into current Websocat architecture. Expect it to be of lower quality than other Websocat modes.");
     info!("Incoming prospective HTTP request");
     let f = WaitForHttpHead::new(r).and_then(|(res, r)|{
         debug!("Got HTTP request head");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,7 +95,7 @@ impl WebsocatConfiguration2 {
     }
 }
 
-/// An immutable chain of fucntions that results in a `Future`s or `Streams` that rely on each other.
+/// An immutable chain of functions that results in a `Future`s or `Streams` that rely on each other.
 /// This is somewhat like a frozen form of `WebsocatConfiguration2`.
 pub struct WebsocatConfiguration3 {
     pub opts: Options,

--- a/src/lints.rs
+++ b/src/lints.rs
@@ -192,7 +192,7 @@ impl WebsocatConfiguration2 {
                 }
             }
             (IsItself, IsItself) => {
-                info!("Special mode, expection from usual one-stdio rule. Acting like `cat(1)`");
+                info!("Special mode, exception from usual one-stdio rule. Acting like `cat(1)`");
                 self.s2 = SpecifierStack::from_str("mirror:")?;
                 if self.opts.unidirectional ^ self.opts.unidirectional_reverse {
                     self.opts.unidirectional = false;
@@ -209,11 +209,11 @@ impl WebsocatConfiguration2 {
         {
             if r#async {
                 if self.s1.addrtype.cls.get_name() == "StdioClass" {
-                    debug!("Substituding StdioClass with AsyncStdioClass at the left");
+                    debug!("Substituting StdioClass with AsyncStdioClass at the left");
                     self.s1.addrtype = SpecifierNode{cls:Rc::new(crate::stdio_peer::AsyncStdioClass)};
                 } 
                 if self.s2.addrtype.cls.get_name() == "StdioClass" {
-                    debug!("Substituding StdioClass with AsyncStdioClass at the right");
+                    debug!("Substituting StdioClass with AsyncStdioClass at the right");
                     self.s2.addrtype = SpecifierNode{cls:Rc::new(crate::stdio_peer::AsyncStdioClass)};
                 } 
             }
@@ -508,7 +508,7 @@ impl WebsocatConfiguration2 {
             if self.opts.unidirectional_reverse || self.opts.exit_on_eof {
                 // OK
             } else {
-                _on_warning("--ping-interval is currenty not very effective without -E or -U")
+                _on_warning("--ping-interval is currently not very effective without -E or -U")
             }
         }
         if self.opts.print_ping_rtts && self.opts.ws_ping_interval.is_none() {

--- a/src/prometheus_peer.rs
+++ b/src/prometheus_peer.rs
@@ -24,12 +24,12 @@ use prometheus::{Encoder, IntCounter, Histogram};
 pub struct GlobalStats {
     /// Number of times write function was called
     w_msgs: IntCounter,
-    /// Nuber of times read function was called
+    /// Number of times read function was called
     r_msgs: IntCounter,
 
-    /// Total nubmer of written bytes to the `prometheus:` node
+    /// Total number of written bytes to the `prometheus:` node
     w_bytes: IntCounter,
-    /// Total nubmer of read bytes from the `prometheus:` node
+    /// Total number of read bytes from the `prometheus:` node
     r_bytes: IntCounter,
 
     /// Number of times `prometheus:` overlay was instantiated

--- a/src/ssl_peer.rs
+++ b/src/ssl_peer.rs
@@ -203,7 +203,7 @@ pub fn ssl_accept(inner_peer: Peer, _l2r: L2rUser, progopt: Rc<Options>) -> Boxe
     let der = progopt
         .pkcs12_der
         .as_ref()
-        .expect("lint should have cought the missing pkcs12_der option");
+        .expect("lint should have caught the missing pkcs12_der option");
     let passwd = progopt
         .pkcs12_passwd
         .as_ref()

--- a/src/stdio_peer.rs
+++ b/src/stdio_peer.rs
@@ -69,7 +69,7 @@ specifier_class!(
     StreamOriented,
     SingleConnect,
     help = r#"
-Like `asyncstdio:`, but intented for inetd(8) usage. [A]
+Like `asyncstdio:`, but intended for inetd(8) usage. [A]
 
 Automatically enables `-q` (`--quiet`) mode.
 

--- a/src/unix_peer.rs
+++ b/src/unix_peer.rs
@@ -76,14 +76,14 @@ Listen for connections on a specified UNIX socket [A]
 Example: forward connections from a UNIX socket to a WebSocket
 
     websocat --unlink unix-l:the_socket ws://127.0.0.1:8089
-    
+
 Example: Accept forwarded WebSocket connections from Nginx
 
     umask 0000
     websocat --unlink -b -E ws-u:unix-l:/tmp/wstest tcp:[::]:22
-      
+
 Nginx config:
-    
+
     location /ws {
         proxy_read_timeout 7d;
         proxy_send_timeout 7d;
@@ -123,7 +123,7 @@ specifier_class!(
         fn construct(self: &UnixDgramClass, just_arg: &str) -> super::Result<Rc<dyn Specifier>> {
             let splits: Vec<&str> = just_arg.split(':').collect();
             if splits.len() != 2 {
-                Err("Expected two colon-separted paths")?;
+                Err("Expected two colon-separated paths")?;
             }
             Ok(Rc::new(UnixDgram(splits[0].into(), splits[1].into())))
         }
@@ -257,7 +257,7 @@ specifier_class!(
         fn construct(self: &AbstractDgramClass, just_arg: &str) -> super::Result<Rc<dyn Specifier>> {
             let splits: Vec<&str> = just_arg.split(':').collect();
             if splits.len() != 2 {
-                Err("Expected two colon-separted addresses")?;
+                Err("Expected two colon-separated addresses")?;
             }
             Ok(Rc::new(UnixDgram(splits[0].into(), splits[1].into())))
         }
@@ -352,14 +352,14 @@ pub fn unix_listen_peer(addr: &Path, opts: &Rc<Options>) -> BoxedNewPeerStream {
         let fdnum: libc::c_int = match addr.to_str().map(|x|x.parse()) {
             Some(Ok(x)) => x,
             _ => {
-                let e: Box<dyn std::error::Error> = From::from("Specify numeric arguemnt instead of path in --accept-from-fd mode");
+                let e: Box<dyn std::error::Error> = From::from("Specify numeric argument instead of path in --accept-from-fd mode");
                 return peer_err_sb(e);
             }
         };
         use std::os::unix::io::FromRawFd;
         let l = unsafe { std::os::unix::net::UnixListener::from_raw_fd(fdnum) } ;
         let _ = l.set_nonblocking(true);
-        let bound =  
+        let bound =
         UnixListener::from_std(l, &tokio_reactor::Handle::default());
         bound
     } else {


### PR DESCRIPTION
Found via `codespell -L crate,isnt`.