### PR TITLE
fix: correct a few typos, mostly in user facing strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Early non-async versions of Websocat should be buildable by even older rustc.
 
 Note that old versions of Websocat may misbehave if built by Rust 1.48 or later due to https://github.com/rust-lang/rust/pull/71274/.
 
-It may be not a good idea to build v1.x line of Websocat with Rust 1.64 due to [IP address representation refactor]. It may expose previously hidden undefined behaviour in legacy depedencies.
+It may be not a good idea to build v1.x line of Websocat with Rust 1.64 due to [IP address representation refactor]. It may expose previously hidden undefined behaviour in legacy dependencies.
 
 [ipaddr]:https://github.com/rust-lang/rust/pull/78802
 
@@ -216,7 +216,7 @@ FLAGS:
     -u, --unidirectional                        Inhibit copying data in one direction
     -U, --unidirectional-reverse                Inhibit copying data in the other direction (or maybe in both directions
                                                 if combined with -u)
-        --accept-from-fd                        [A] Do not call `socket(2)` in UNIX socket listerer peer, start with
+        --accept-from-fd                        [A] Do not call `socket(2)` in UNIX socket listener peer, start with
                                                 `accept(2)` using specified file descriptor number as argument instead
                                                 of filename
         --unlink                                [A] Unlink listening UNIX socket before binding to it
@@ -435,7 +435,7 @@ Full list of address types:
 	assert2:        	Check the input. [A]
 	seqpacket:      	Connect to AF_UNIX SOCK_SEQPACKET socket. Argument is a filesystem path. [A]
 	seqpacket-listen:	Listen for connections on a specified AF_UNIX SOCK_SEQPACKET socket [A]
-	random:         	Generage random bytes when being read from, discard written bytes.
+	random:         	Generate random bytes when being read from, discard written bytes.
 Full list of overlays:
 	ws-upgrade:     	WebSocket upgrader / raw server. Specify your own protocol instead of usual TCP. [A]
 	http-request:   	[A] Issue HTTP request, receive a 1xx or 2xx reply, then pass
@@ -454,7 +454,7 @@ Full list of overlays:
 	timestamp:      	[A] Prepend timestamp to each incoming message.
 	socks5-connect: 	SOCKS5 proxy client (raw) [A]
 	socks5-bind:    	SOCKS5 proxy client (raw, bind command) [A]
-	crypto:         	[A] Encrypts written messages and decryptes (and verifies) read messages with a static key, using ChaCha20-Poly1305 algorithm.
+	crypto:         	[A] Encrypts written messages and decrypts (and verifies) read messages with a static key, using ChaCha20-Poly1305 algorithm.
 	prometheus:     	[A] Account connections, messages, bytes and other data and expose Prometheus metrics on a separate port.
 	exit_on_specific_byte:	[A] Turn specific byte into a EOF, allowing user to escape interactive Websocat session
 ```

--- a/doc.md
+++ b/doc.md
@@ -103,7 +103,7 @@ FLAGS:
     -u, --unidirectional                        Inhibit copying data in one direction
     -U, --unidirectional-reverse                Inhibit copying data in the other direction (or maybe in both directions
                                                 if combined with -u)
-        --accept-from-fd                        [A] Do not call `socket(2)` in UNIX socket listerer peer, start with
+        --accept-from-fd                        [A] Do not call `socket(2)` in UNIX socket listener peer, start with
                                                 `accept(2)` using specified file descriptor number as argument instead
                                                 of filename
         --unlink                                [A] Unlink listening UNIX socket before binding to it
@@ -892,7 +892,7 @@ Example: forward connections from a UNIX seqpacket socket to a WebSocket
 Internal name for --dump-spec: Random
 
 
-Generage random bytes when being read from, discard written bytes.
+Generate random bytes when being read from, discard written bytes.
 
     websocat -b random: ws://127.0.0.1/flood
 
@@ -1188,7 +1188,7 @@ See an example in moreexamples.md for more thorough example.
 Internal name for --dump-spec: Crypto
 
 
-[A] Encrypts written messages and decryptes (and verifies) read messages with a static key, using ChaCha20-Poly1305 algorithm.
+[A] Encrypts written messages and decrypts (and verifies) read messages with a static key, using ChaCha20-Poly1305 algorithm.
 
 Do not not use in stream mode - packet boundaries are significant.
 

--- a/src/crypto_peer.rs
+++ b/src/crypto_peer.rs
@@ -43,7 +43,7 @@ specifier_class!(
     MessageOriented,
     MulticonnectnessDependsOnInnerType,
     help = r#"
-[A] Encrypts written messages and decryptes (and verifies) read messages with a static key, using ChaCha20-Poly1305 algorithm.
+[A] Encrypts written messages and decrypts (and verifies) read messages with a static key, using ChaCha20-Poly1305 algorithm.
 
 Do not not use in stream mode - packet boundaries are significant.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,7 +171,7 @@ struct Opt {
 
     #[structopt(
         long = "accept-from-fd",
-        help = "[A] Do not call `socket(2)` in UNIX socket listerer peer, start with `accept(2)` using specified file descriptor number as argument instead of filename"
+        help = "[A] Do not call `socket(2)` in UNIX socket listener peer, start with `accept(2)` using specified file descriptor number as argument instead of filename"
     )]
     unix_socket_accept_from_fd: bool,
 

--- a/src/readdebt.rs
+++ b/src/readdebt.rs
@@ -42,7 +42,7 @@ impl ReadDebt {
             self.0 = Some(buf_in[l..].to_vec());
         }
 
-        debug!("Fullfulling the debt of {} bytes", l);
+        debug!("Fulfilling the debt of {} bytes", l);
         if l == 0 {
             match self.2 {
                 ZeroMessagesHandling::Deliver => (),

--- a/src/reconnect_peer.rs
+++ b/src/reconnect_peer.rs
@@ -110,7 +110,7 @@ impl State {
 
                         if !aux.already_warned {
                             aux.already_warned = true;
-                            warn!("Reconnecting failed. Further failed reconnects announncements will have lower severity.");
+                            warn!("Reconnecting failed. Further failed reconnects announcements will have lower severity.");
                         } else {
                             info!("Reconnecting failed.");
                         }

--- a/src/socks5_peer.rs
+++ b/src/socks5_peer.rs
@@ -113,7 +113,7 @@ fn read_socks_reply(p: Peer) -> RSRRet {
                 }
                 if reply[1] != b'\x00' {
                     let msg = match reply[1] {
-                        1 => "SOCKS: General SOCKS server failuire",
+                        1 => "SOCKS: General SOCKS server failure",
                         2 => "SOCKS connection not allowed",
                         3 => "SOCKS: network unreachable",
                         4 => "SOCKS: host unreachable",

--- a/src/trivial_peer.rs
+++ b/src/trivial_peer.rs
@@ -414,7 +414,7 @@ specifier_class!(
     MessageOriented,
     SingleConnect,
     help = r#"
-Generage random bytes when being read from, discard written bytes.
+Generate random bytes when being read from, discard written bytes.
 
     websocat -b random: ws://127.0.0.1/flood
 

--- a/src/wasm_transform_peer.rs
+++ b/src/wasm_transform_peer.rs
@@ -156,7 +156,7 @@ pub fn load_symbol(spec: &str) -> crate::Result<Handle> {
     let transform = instance.get_typed_func::<(u32, u32, u32, u32, u32), u32, _>(&mut env.store, symname)?;
     let malloc = instance.get_typed_func::<u32, u32, _>(&mut env.store, "malloc")?;
     let free = instance.get_typed_func::<u32, (), _>(&mut env.store, "free")?;
-    debug!("Instanitated");
+    debug!("Instantiated");
     
     let h = Handle {
         mem,


### PR DESCRIPTION
Hi Vitaly

While skimming through the codebase, looking to discover how hard it would be to implement Socket.io support as you mentioned in https://github.com/vi/websocat/issues/21#issuecomment-439129842, I stumbled upon a few typos.

So here's a quick PR with the ones I found.

Thanks for this great tool.