### PR TITLE
Update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,9 +621,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.153"
+version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
 
 [[package]]
 name = "linux-raw-sys"


### PR DESCRIPTION
Libc needs to be updated to 0.2.155 because websocat compiles based on musl loongarch64 and reports an error:

```
error[E0573]: expected type, found function `stat64`
  --> /home/alpine/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.153/src/unix/linux_like/linux/musl/lfs64.rs:95:67
   |
95 | pub unsafe extern "C" fn lstat64(path: *const ::c_char, buf: *mut ::stat64) -> ::c_int {
   |                                                                   ^^^^^^^^ not a type

error[E0412]: cannot find type `c_char` in the crate root
   --> /home/alpine/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.153/src/unix/linux_like/linux/musl/lfs64.rs:219:52
    |
219 | pub unsafe extern "C" fn stat64(pathname: *const ::c_char, statbuf: *mut ::stat64) -> ::c_int {
    |                                                    ^^^^^^
    |
   ::: /home/alpine/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libc-0.2.153/src/unix/mod.rs:6:1
```

Libc release notes : https://github.com/rust-lang/libc/releases

Thanks.