### PR TITLE
Changed `as` to `AS` in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM rust:1.72-alpine3.18 as cargo-build
+FROM rust:1.72-alpine3.18 AS cargo-build
 
 RUN apk add --no-cache musl-dev pkgconfig openssl-dev
 


### PR DESCRIPTION
Syntax fix: 
Eliminates warning when running `docker build`.

Example:
```
 1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 2)
```
