### PR TITLE
try a debian arm build

### DIFF
--- a/.github/workflows/container-image-buildah.yml
+++ b/.github/workflows/container-image-buildah.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Sanitize Platforms
         id: platforms
         run: |
-          platforms="${{ inputs.platforms == '' && 'linux/amd64' || inputs.platforms }}"
+          platforms="${{ inputs.platforms == '' && 'linux/amd64,linux/arm64' || inputs.platforms }}"
           archs="$( sed -e 's#linux/##g' <<< $platforms )"
           echo "platforms=$platforms" >> $GITHUB_OUTPUT
           echo "archs=$archs" >> $GITHUB_OUTPUT

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,15 @@
 # Build stage
-FROM rust:1.72-alpine3.18 AS cargo-build
+FROM rust:1.72.1-bookworm AS cargo-build
 
-RUN apk add --no-cache musl-dev pkgconfig openssl-dev
+RUN apt-get update
+RUN apt-get install -y libgcc-12-dev libc6-dev pkg-config libssl-dev
 
 WORKDIR /src/websocat
 ENV RUSTFLAGS='-Ctarget-feature=-crt-static'
 
 COPY Cargo.toml Cargo.toml
-ARG CARGO_OPTS="--features=workaround1,seqpacket,prometheus_peer,prometheus/process,crypto_peer"
+# ARG CARGO_OPTS="--features=workaround1,seqpacket,prometheus_peer,prometheus/process,crypto_peer"
+ARG CARGO_OPTS="--features=ssl,workaround1,seqpacket,unix_stdio,prometheus_peer,prometheus/process,crypto_peer"
 
 RUN mkdir src/ &&\
     echo "fn main() {println!(\"if you see this, the build broke\")}" > src/main.rs && \
@@ -19,9 +21,12 @@ RUN cargo build --release $CARGO_OPTS && \
     strip target/release/websocat
 
 # Final stage
-FROM alpine:3.18
+FROM debian:bookworm
 
-RUN apk add --no-cache libgcc
+RUN apt-get update
+RUN apt-get install -y libssl3
+RUN apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /
 COPY --from=cargo-build /src/websocat/target/release/websocat /usr/local/bin/


### PR DESCRIPTION
I remembered that I saw other rust projects having certain issues with musl.

So this is same build just based on debian stable so it compiles with glibc.

And lo! It worked.

If we can use rust 1.63 which is shipped with debian, instead of using rust images, we can also enable RISC-V and other architectures. Because the rust images appear to only have amd64 and arm64.

This is the build in my fork, lets see if it pass again: https://github.com/akostadinov/websocat/actions/runs/11671736530

P.S. I'm fine if you don't want to switch to debian. Just I was curious what was going on and played with it. But I don't have a horse here. Just somehow happy to see other archs picking up, not only x86_64