### PR TITLE
Bump rust version to 1.80.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM rust:1.72-alpine3.18 AS cargo-build
+FROM rust:1.80.1-alpine3.20 AS cargo-build
 
 RUN apk add --no-cache musl-dev pkgconfig openssl-dev
 
@@ -19,7 +19,7 @@ RUN cargo build --release $CARGO_OPTS && \
     strip target/release/websocat
 
 # Final stage
-FROM alpine:3.18
+FROM alpine:3.20
 
 RUN apk add --no-cache libgcc
 

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,5 +1,5 @@
 # Build stage
-FROM rust:1.72.1-bookworm AS cargo-build
+FROM rust:1.80.1-bookworm AS cargo-build
 
 RUN apt-get update
 RUN apt-get install -y libgcc-12-dev libc6-dev pkg-config libssl-dev


### PR DESCRIPTION
Bump the version to solve the below building error.

```
error: package `native-tls v0.2.14` cannot be built because it requires
rustc 1.80.0 or newer, while the currently active rustc version is
1.72.1
```