### PR TITLE
Log response headers

### DIFF
--- a/src/ws_client_peer.rs
+++ b/src/ws_client_peer.rs
@@ -171,8 +171,8 @@ where
     };
     Box::new(
         after_connect
-            .map(move |(duplex, _)| {
-                info!("Connected to ws",);
+            .map(move |(duplex, headers)| {
+                info!("Connected to ws, response headers: {:?}", headers);
                 let close_on_shutdown = !opts.websocket_dont_close;
                 super::ws_peer::finish_building_ws_peer(&opts, duplex, close_on_shutdown, None)
             })


### PR DESCRIPTION
This adds logging of the HTTP response headers
For diagnostics with the `-v` flag it is helpful to see the response headers from the server.