### PR TITLE
Support SSLKEYLOGFILE for TLS session key logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1605,6 +1605,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-openssl"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4646ae1fd623393de3d796ea53af75acd02938dd5579544fbd6d236d041978a6"
+dependencies = [
+ "futures",
+ "openssl",
+ "tokio-io",
+]
+
+[[package]]
 name = "tokio-process"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1903,6 +1914,7 @@ dependencies = [
  "log 0.4.21",
  "native-tls",
  "net2",
+ "openssl",
  "openssl-probe",
  "openssl-sys",
  "prometheus",
@@ -1921,6 +1933,7 @@ dependencies = [
  "tokio-file-unix",
  "tokio-io",
  "tokio-named-pipes",
+ "tokio-openssl",
  "tokio-process",
  "tokio-reactor",
  "tokio-signal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ openssl-probe = { version = "0.1.2", optional = true }
 smart-default = "0.3.0"
 tokio-tls = {version = "0.2.0", optional = true}
 native-tls = {version = "0.2.1", optional = true}
+openssl = {version = "0.10", optional = true}
+tokio-openssl = {version = "0.2", optional = true}
 readwrite = {version = "0.1.1", optional = true, features = ["tokio"]}
 derivative="1.0.0"
 tokio-codec = "0.1.1"
@@ -83,7 +85,7 @@ tokio-named-pipes = {version="0.1.0", optional=true}
 [features]
 default = ["signal_handler", "tokio-process", "unix_stdio", "windows_named_pipes", "ssl", "compression"]
 unix_stdio = []
-ssl = ["websocket/async-ssl", "tokio-tls", "native-tls", "readwrite", "openssl-sys"]
+ssl = ["websocket/async-ssl", "tokio-tls", "native-tls", "readwrite", "openssl-sys", "openssl", "tokio-openssl"]
 signal_handler = ["tokio-signal"]
 workaround1=[]
 seqpacket=[]

--- a/src/ssl_peer.rs
+++ b/src/ssl_peer.rs
@@ -6,13 +6,69 @@ use super::{box_up_err, peer_err, BoxedNewPeerFuture, Peer};
 use super::{ConstructParams, L2rUser, Options, PeerConstructor, Specifier};
 
 pub extern crate native_tls;
+pub extern crate openssl;
 extern crate readwrite;
+pub extern crate tokio_openssl;
 extern crate tokio_tls;
 
 use self::native_tls::{Identity as Pkcs12, TlsAcceptor, TlsConnector};
 use self::tokio_tls::{TlsAcceptor as TlsAcceptorExt, TlsConnector as TlsConnectorExt};
 
 use std::ffi::{OsStr, OsString};
+
+pub fn get_keylog_path() -> Option<String> {
+    std::env::var("SSLKEYLOGFILE")
+        .ok()
+        .filter(|s| !s.is_empty())
+}
+
+/// Set up TLS key logging callback on an OpenSSL context builder.
+/// Opens the file at `keylog_path` in append mode and installs a callback
+/// that writes NSS key log format lines to it.
+pub fn configure_keylog(ctx: &mut openssl::ssl::SslConnectorBuilder, keylog_path: &str) {
+    match std::fs::OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(keylog_path)
+    {
+        Ok(file) => {
+            let writer = std::sync::Mutex::new(file);
+            ctx.set_keylog_callback(move |_ssl, line| {
+                if let Ok(mut f) = writer.lock() {
+                    use std::io::Write;
+                    let _ = writeln!(f, "{}", line);
+                }
+            });
+            info!("TLS key logging enabled, writing to {}", keylog_path);
+        }
+        Err(e) => {
+            warn!("Failed to open SSLKEYLOGFILE '{}': {}", keylog_path, e);
+        }
+    }
+}
+
+/// Same as configure_keylog but for SslAcceptorBuilder (which also derefs to SslContextBuilder).
+fn configure_keylog_acceptor(ctx: &mut openssl::ssl::SslAcceptorBuilder, keylog_path: &str) {
+    match std::fs::OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(keylog_path)
+    {
+        Ok(file) => {
+            let writer = std::sync::Mutex::new(file);
+            ctx.set_keylog_callback(move |_ssl, line| {
+                if let Ok(mut f) = writer.lock() {
+                    use std::io::Write;
+                    let _ = writeln!(f, "{}", line);
+                }
+            });
+            info!("TLS key logging enabled, writing to {}", keylog_path);
+        }
+        Err(e) => {
+            warn!("Failed to open SSLKEYLOGFILE '{}': {}", keylog_path, e);
+        }
+    }
+}
 
 pub fn interpret_pkcs12(x: &OsStr) -> ::std::result::Result<Vec<u8>, OsString> {
     match (|| {
@@ -146,6 +202,73 @@ See [moreexamples.md](./moreexamples.md) for info about generation of `q.pkcs12`
 
 use tokio_io::AsyncRead;
 
+fn ssl_connect_openssl(
+    inner_peer: Peer,
+    dom: Option<String>,
+    tls_insecure: bool,
+    client_identity: Option<Vec<u8>>,
+    client_identity_password: Option<String>,
+    keylog_path: String,
+) -> BoxedNewPeerFuture {
+    use self::openssl::ssl::{SslConnector as OpensslConnector, SslMethod, SslVerifyMode};
+    use self::tokio_openssl::SslConnectorExt as OpensslConnectorExt;
+
+    let hup = inner_peer.2;
+    let squashed_peer = readwrite::ReadWriteAsync::new(inner_peer.0, inner_peer.1);
+
+    let mut builder = match OpensslConnector::builder(SslMethod::tls()) {
+        Ok(b) => b,
+        Err(e) => return peer_err(e),
+    };
+
+    configure_keylog(&mut builder, &keylog_path);
+
+    if tls_insecure || dom.is_none() {
+        builder.set_verify(SslVerifyMode::NONE);
+    }
+
+    if let Some(pkcs12_der) = client_identity {
+        match openssl::pkcs12::Pkcs12::from_der(&pkcs12_der) {
+            Ok(pkcs12) => match pkcs12.parse2(&client_identity_password.unwrap_or_default()) {
+                Ok(parsed) => {
+                    if let Some(ref cert) = parsed.cert {
+                        if let Err(e) = builder.set_certificate(cert) {
+                            error!("Failed to set client certificate: {}", e);
+                        }
+                    }
+                    if let Some(ref pkey) = parsed.pkey {
+                        if let Err(e) = builder.set_private_key(pkey) {
+                            error!("Failed to set client private key: {}", e);
+                        }
+                    }
+                }
+                Err(e) => error!("Failed to parse client PKCS12 identity: {}", e),
+            },
+            Err(e) => error!("Failed to decode client PKCS12 DER: {}", e),
+        }
+    }
+
+    let connector = builder.build();
+    let domain = dom.unwrap_or_else(|| "domainverificationdisabled".to_string());
+
+    info!("Connecting to TLS (with key logging)");
+    Box::new(
+        connector
+            .connect_async(&domain, squashed_peer)
+            .map_err(|e| {
+                Box::new(super::simple_err(format!(
+                    "OpenSSL TLS handshake error: {}",
+                    e
+                ))) as Box<dyn std::error::Error>
+            })
+            .and_then(move |tls_stream| {
+                info!("Connected to TLS (with key logging)");
+                let (r, w) = tls_stream.split();
+                ok(Peer::new(r, w, hup))
+            }),
+    )
+}
+
 pub fn ssl_connect(
     inner_peer: Peer,
     _l2r: L2rUser,
@@ -154,6 +277,17 @@ pub fn ssl_connect(
     client_identity : Option<Vec<u8>>,
     client_identity_password : Option<String>,
 ) -> BoxedNewPeerFuture {
+    if let Some(keylog_path) = get_keylog_path() {
+        return ssl_connect_openssl(
+            inner_peer,
+            dom,
+            tls_insecure,
+            client_identity,
+            client_identity_password,
+            keylog_path,
+        );
+    }
+
     let hup = inner_peer.2;
     let squashed_peer = readwrite::ReadWriteAsync::new(inner_peer.0, inner_peer.1);
 
@@ -213,7 +347,89 @@ pub fn ssl_connect(
     }
 }
 
+fn ssl_accept_openssl(
+    inner_peer: Peer,
+    progopt: Rc<Options>,
+    keylog_path: String,
+) -> BoxedNewPeerFuture {
+    use self::openssl::ssl::{SslAcceptor as OpensslAcceptor, SslMethod};
+    use self::tokio_openssl::SslAcceptorExt as OpensslAcceptorExt;
+
+    let hup = inner_peer.2;
+    let squashed_peer = readwrite::ReadWriteAsync::new(inner_peer.0, inner_peer.1);
+
+    let der = progopt
+        .pkcs12_der
+        .as_ref()
+        .expect("lint should have caught the missing pkcs12_der option");
+    let passwd = progopt.pkcs12_passwd.as_deref().unwrap_or("");
+
+    let mut builder = match OpensslAcceptor::mozilla_intermediate(SslMethod::tls()) {
+        Ok(b) => b,
+        Err(e) => return peer_err(e),
+    };
+
+    configure_keylog_acceptor(&mut builder, &keylog_path);
+
+    match openssl::pkcs12::Pkcs12::from_der(der) {
+        Ok(pkcs12) => match pkcs12.parse2(passwd) {
+            Ok(parsed) => {
+                if let Some(ref cert) = parsed.cert {
+                    if let Err(e) = builder.set_certificate(cert) {
+                        error!("Failed to set server certificate: {}", e);
+                        return peer_err(e);
+                    }
+                }
+                if let Some(ref pkey) = parsed.pkey {
+                    if let Err(e) = builder.set_private_key(pkey) {
+                        error!("Failed to set server private key: {}", e);
+                        return peer_err(e);
+                    }
+                }
+                if let Some(ref ca_certs) = parsed.ca {
+                    for ca_cert in ca_certs.iter() {
+                        if let Err(e) = builder.add_extra_chain_cert(ca_cert.to_owned()) {
+                            error!("Failed to add chain certificate: {}", e);
+                        }
+                    }
+                }
+            }
+            Err(e) => {
+                error!("Failed to parse server PKCS12 identity: {}", e);
+                return peer_err(e);
+            }
+        },
+        Err(e) => {
+            error!("Failed to decode server PKCS12 DER: {}", e);
+            return peer_err(e);
+        }
+    }
+
+    let acceptor = builder.build();
+
+    debug!("Accepting a TLS connection (with key logging)");
+    Box::new(
+        acceptor
+            .accept_async(squashed_peer)
+            .map_err(|e| {
+                Box::new(super::simple_err(format!(
+                    "OpenSSL TLS accept error: {}",
+                    e
+                ))) as Box<dyn std::error::Error>
+            })
+            .and_then(move |tls_stream| {
+                info!("Accepted TLS connection (with key logging)");
+                let (r, w) = tls_stream.split();
+                ok(Peer::new(r, w, hup))
+            }),
+    )
+}
+
 pub fn ssl_accept(inner_peer: Peer, _l2r: L2rUser, progopt: Rc<Options>) -> BoxedNewPeerFuture {
+    if let Some(keylog_path) = get_keylog_path() {
+        return ssl_accept_openssl(inner_peer, progopt, keylog_path);
+    }
+
     let hup = inner_peer.2;
     let squashed_peer = readwrite::ReadWriteAsync::new(inner_peer.0, inner_peer.1);
 

--- a/src/ws_client_peer.rs
+++ b/src/ws_client_peer.rs
@@ -180,8 +180,95 @@ where
     ) as BoxedNewPeerFuture
 }
 
+#[cfg(feature = "ssl")]
+fn get_ws_client_peer_openssl(uri: &Url, opts: Rc<Options>) -> BoxedNewPeerFuture {
+    use super::ssl_peer::openssl;
+    use openssl::ssl::{SslConnector as OpensslConnector, SslMethod, SslVerifyMode};
+    use std::net::ToSocketAddrs;
+    use tokio_io::AsyncRead;
+    use tokio_openssl::SslConnectorExt as OpensslConnectorExt;
+
+    let tls_insecure = opts.tls_insecure;
+    let client_ident = opts.client_pkcs12_der.clone();
+    let client_ident_passwd = opts.client_pkcs12_passwd.clone();
+
+    let host = match uri.host_str() {
+        Some(h) => h.to_string(),
+        None => return peer_strerr("wss:// URL has no host"),
+    };
+    let port = uri.port_or_known_default().unwrap_or(443);
+
+    let addrs: Vec<SocketAddr> = match (&*host, port).to_socket_addrs() {
+        Ok(a) => a.collect(),
+        Err(e) => return peer_err(e),
+    };
+    if addrs.is_empty() {
+        return peer_strerr("DNS resolution returned no addresses");
+    }
+
+    let mut builder = match OpensslConnector::builder(SslMethod::tls()) {
+        Ok(b) => b,
+        Err(e) => return peer_err(e),
+    };
+
+    let keylog_path = super::ssl_peer::get_keylog_path().unwrap();
+    super::ssl_peer::configure_keylog(&mut builder, &keylog_path);
+
+    if tls_insecure {
+        builder.set_verify(SslVerifyMode::NONE);
+    }
+
+    if let Some(pkcs12_der) = client_ident {
+        if let Ok(pkcs12) = openssl::pkcs12::Pkcs12::from_der(&pkcs12_der) {
+            let passwd = client_ident_passwd.unwrap_or_default();
+            if let Ok(parsed) = pkcs12.parse2(&passwd) {
+                if let Some(ref cert) = parsed.cert {
+                    let _ = builder.set_certificate(cert);
+                }
+                if let Some(ref pkey) = parsed.pkey {
+                    let _ = builder.set_private_key(pkey);
+                }
+            }
+        }
+    }
+
+    let connector = builder.build();
+    let uri_clone = uri.clone();
+    let opts_clone = opts.clone();
+
+    Box::new(
+        crate::net_peer::tcp_race(&addrs)
+            .map_err(|e| e as Box<dyn std::error::Error>)
+            .and_then(move |tcp_stream| {
+                connector
+                    .connect_async(&host, tcp_stream)
+                    .map_err(|e| {
+                        Box::new(crate::util::simple_err(format!(
+                            "OpenSSL TLS handshake error (wss): {}",
+                            e
+                        ))) as Box<dyn std::error::Error>
+                    })
+                    .and_then(move |tls_stream| {
+                        info!("Connected to TLS for wss:// (with key logging)");
+                        let (r, w) = tls_stream.split();
+                        let peer = Peer::new(r, w, None);
+                        get_ws_client_peer_wrapped(&uri_clone, peer, opts_clone)
+                    })
+            }),
+    )
+}
+
 pub fn get_ws_client_peer(uri: &Url, opts: Rc<Options>) -> BoxedNewPeerFuture {
     info!("get_ws_client_peer");
+
+    #[cfg(feature = "ssl")]
+    {
+        if uri.scheme() == "wss" {
+            if let Some(_) = super::ssl_peer::get_keylog_path() {
+                return get_ws_client_peer_openssl(uri, opts);
+            }
+        }
+    }
 
     #[allow(unused)]
     let tls_insecure = opts.tls_insecure;


### PR DESCRIPTION
When the SSLKEYLOGFILE environment variable is set, bypass native-tls and use the openssl crate directly to enable SSL_CTX_set_keylog_callback. This writes TLS session keys in NSS key log format, allowing Wireshark and similar tools to decrypt captured TLS traffic for debugging.

Coverage includes all three TLS code paths: ssl-connect/ssl-accept overlays, wss-listen, and wss:// client URLs. When SSLKEYLOGFILE is unset, the existing native-tls behavior is completely unchanged.