### PR TITLE
Handle canceled pinger in ws_peer.rs

### DIFF
--- a/src/ws_peer.rs
+++ b/src/ws_peer.rs
@@ -555,6 +555,10 @@ impl<T: WsStream + 'static> ::futures::Future for WsPinger<T> {
         use futures::AsyncSink;
         loop {
             match self.aborter.poll() {
+                Err(futures::sync::oneshot::Canceled) => {
+                    debug!("Pinger canceled");
+                    return Ok(Async::Ready(()));
+                },                    
                 Err(e) => warn!("unsync/oneshot: {}", e),
                 Ok(Async::NotReady) => (),
                 Ok(Async::Ready(())) => {


### PR DESCRIPTION
Prevent unneeded warnings
`[WARN  websocat::ws_peer] unsync/oneshot: oneshot canceled`

[oneshot::Reciever](https://docs.smithy.rs/futures/unsync/oneshot/struct.Receiver.html#method.close) `poll` has a special return case called Canceled.

> If Canceled is returned from poll then no message was sent.

This should proably be ignored.

